### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ readme = "README.md"
 [dependencies]
 byteorder = "1"
 bytes = "1"
-postgres = { version = "0", optional = true }
+postgres = { version = "0.19", optional = true }
 diesel = { version = "2", features = ["postgres"], optional = true }
-sqlx = { version = "0", features = ["postgres"], optional = true }
+sqlx = { version = "0.6", features = ["postgres"], optional = true }
 
 [dev-dependencies]
 sqlx = { version = "0", features = [ "runtime-async-std-native-tls" ] }


### PR DESCRIPTION
Mentioning "0" would mean cargo would pick the latest dependency which is versioned "0.*" which would include versions incompatible with the one that this crate was written with and may break your create.