### PR TITLE
Remove sqlx default-features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ byteorder = "1"
 bytes = "1"
 postgres = { version = "0.19", optional = true }
 diesel = { version = "2", features = ["postgres"], optional = true }
-sqlx = { version = ">= 0.5, < 0.8", features = ["postgres"], optional = true }
+sqlx = { version = ">= 0.5, < 0.8", default-features = false, features = ["postgres"], optional = true }
 
 [dev-dependencies]
-sqlx = { version = "0", features = ["runtime-async-std-native-tls"] }
+sqlx = { version = "0", default-features = false, features = ["runtime-async-std-native-tls"] }
 async-std = { version = "1", features = ["attributes"] }
 
 [features]


### PR DESCRIPTION
## Description

Removes `default-features` for `sqlx`, since `pgvector` does not rely on the [any connector, macros, migrate, or json](https://github.com/launchbadge/sqlx/blob/e80291b2a771bf66e9c03f068fd196c7a47c1967/Cargo.toml#L55). Not sure about the `diesel` and `postgres` dependencies, but it might be good to only pull in the required features for them too.

Noticed this was pulling in dependencies like `sqlx-macros` unnecessarily, also causing it to get cleaned by `cargo sqlx prepare --workspace`.

Thanks for the crate.

## How to test or review this PR

Running the tests seems sufficient.

```
cargo test --all-features --all-targets
```

```
running 5 tests
test vector::tests::test_to_vec ... ok
test vector::tests::test_into ... ok
test postgres_ext::tests::it_works ... ok
test sqlx_ext::tests::it_works ... ok
test diesel_ext::tests::it_works ... ok

test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.08s
```