### PR TITLE
Use types from the lighter-weight postgres-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,16 +14,17 @@ doctest = false
 
 [dependencies]
 bytes = { version = "1", optional = true }
-postgres = { version = "0.19", default-features = false, optional = true }
+postgres-types = { version = "0.2", default-features = false, optional = true }
 diesel = { version = "2", default-features = false, features = ["postgres"], optional = true }
 sqlx = { version = ">= 0.5, < 0.8", default-features = false, features = ["postgres"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
+postgres = { version = "0.19", default-features = false }
 diesel = { version = "2", default-features = false, features = ["32-column-tables"] }
 sqlx = { version = "0", default-features = false, features = ["runtime-async-std-native-tls"] }
 async-std = { version = "1", features = ["attributes"] }
 serde_json = "1"
 
 [features]
-postgres = ["dep:postgres", "dep:bytes"]
+postgres = ["dep:postgres-types", "dep:bytes"]

--- a/src/postgres_ext/vector.rs
+++ b/src/postgres_ext/vector.rs
@@ -1,5 +1,5 @@
 use bytes::{BufMut, BytesMut};
-use postgres::types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
+use postgres_types::{to_sql_checked, FromSql, IsNull, ToSql, Type};
 use std::convert::TryInto;
 use std::error::Error;
 


### PR DESCRIPTION
The imports for `postgres::types` are just a re-export of `tokio_postgres::types`, so this reduces the number of transitive dependencies brought in with the `postgres` feature (in particular, eliminating the `full` feature on Tokio).