### PR TITLE
Add Eq trait to bit vectors

### DIFF
--- a/src/bit.rs
+++ b/src/bit.rs
@@ -5,7 +5,7 @@ use crate::diesel_ext::bit::BitType;
 use diesel::{deserialize::FromSqlRow, expression::AsExpression};
 
 /// A bit string.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "diesel", derive(FromSqlRow, AsExpression))]
 #[cfg_attr(feature = "diesel", diesel(sql_type = BitType))]
 pub struct Bit {


### PR DESCRIPTION
For other vector types, you are unable to have Eq because they would be comparing floating point numbers. Bit vectors don't have this problem though and should allow for Eq comparisons.