### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,14 +15,14 @@ doctest = false
 [dependencies]
 bytes = { version = "1", optional = true }
 postgres-types = { version = "0.2", default-features = false, optional = true }
-diesel = { version = "2", default-features = false, features = ["postgres"], optional = true }
+diesel = { version = "2.2.3", default-features = false, features = ["postgres"], optional = true }
 sqlx = { version = "0.8", default-features = false, features = ["postgres"], optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 half = { version = "2", default-features = false, optional = true }
 
 [dev-dependencies]
 postgres = { version = "0.19", default-features = false }
-diesel = { version = "2", default-features = false, features = ["32-column-tables"] }
+diesel = { version = "2.2.3", default-features = false, features = ["32-column-tables"] }
 sqlx = { version = "0", default-features = false, features = ["runtime-async-std-native-tls"] }
 async-std = { version = "1", features = ["attributes"] }
 serde_json = "1"


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)