### PR TITLE
Implement casting for Vector to HalfVec

### DIFF
--- a/src/diesel_ext/expression_methods.rs
+++ b/src/diesel_ext/expression_methods.rs
@@ -2,6 +2,9 @@ use diesel::expression::{AsExpression, Expression};
 use diesel::pg::Pg;
 use diesel::sql_types::{Double, SqlType};
 
+#[cfg(feature = "halfvec")]
+use crate::diesel_ext::halfvec::HalfVecCast;
+
 diesel::infix_operator!(L2Distance, " <-> ", Double, backend: Pg);
 diesel::infix_operator!(MaxInnerProduct, " <#> ", Double, backend: Pg);
 diesel::infix_operator!(CosineDistance, " <=> ", Double, backend: Pg);
@@ -10,6 +13,11 @@ diesel::infix_operator!(HammingDistance, " <~> ", Double, backend: Pg);
 diesel::infix_operator!(JaccardDistance, " <%> ", Double, backend: Pg);
 
 pub trait VectorExpressionMethods: Expression + Sized {
+    #[cfg(feature = "halfvec")]
+    fn cast_to_halfvec(self, dim: usize) -> HalfVecCast<Self> {
+        HalfVecCast::new(self, dim)
+    }
+
     fn l2_distance<T>(self, other: T) -> L2Distance<Self, T::Expression>
     where
         Self::SqlType: SqlType,


### PR DESCRIPTION
This will enable some usage, as disccused in this [issue](https://github.com/pgvector/pgvector/issues/461) 
```sql
CREATE TABLE items (id bigserial PRIMARY KEY, embedding vector(3072));
CREATE INDEX ON items USING hnsw ((embedding::halfvec(3072)) halfvec_cosine_ops);

-- and query with
SELECT * FROM items ORDER BY embedding::halfvec(3072) <=> '[1,2,3]' LIMIT 5;
```

Taken this snippet 
```rust
let mut conn = establish_connection();
let embed = HalfVector::from_f32_slice(&[1.0, 2.0, 5.0]);
let neighbors = items::table
    .order(
        items::embedding
            .cast::<Nullable<pgvector::sql_types::HalfVector>>()
            .l2_distance(embed.clone()),
    )
    .load::<Item>(&mut conn)
    .unwrap();
```
It produces the following query:
`SELECT "items"."id", "items_diesel"."embedding" FROM "items" ORDER BY CAST("items_diesel"."embedding" AS halfvec) <-> $1 LIMIT $2 -- binds: [HalfVector([1.0, 2.0, 5.0]), 5]`
But I actually don't now if not providing the dimension have an impact ?

Second question on the binary vector, for the example in the following query present in the docs:
```SELECT * FROM items ORDER BY binary_quantize(embedding)::bit(3) <~> binary_quantize('[1,-2,3]') LIMIT 5;```
Is the cast necessary? The documentation mentioned that binary_quantize already returns a bit vector.